### PR TITLE
Docker and release  support

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -1,0 +1,150 @@
+---
+name: CI/CD
+
+on:
+  workflow_dispatch:
+    inputs:
+      create-release:
+        description: 'Choose whether to relaese new version or not'
+        required: true
+        type: boolean
+        default: false
+      release-type:
+        description: 'Choose release type'
+        required: false
+        default: 'patch'
+        type: choice
+        options:
+        - patch
+        - minor
+        - major
+        - custom
+      custom-release-version:
+        description: 'Choose a custom version to release'
+        required: false
+        type: string
+        default: ""
+      custom-next-version:
+        description: 'Choose a custom next version for the app'
+        required: false
+        type: string
+        default: ""
+      custom-tag-message:
+        description: 'Add a custom description of the release'
+        required: false
+        type: string
+        default: ""
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    if: always()
+    name: Build and push docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      # To report GitHub Actions status checks
+      statuses: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: maven
+
+      - name: Build with Maven
+        run: mvn -B clean package --file pom.xml
+
+      # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+      - name: Maven Dependency Tree Dependency Submission
+        uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: weedesigners/hermes
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  release:
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.create-release }}
+    name: Release new Hermes version (Bumb app version)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      statuses: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: maven
+      
+      - name: Remove Snapshot
+        run: |
+          mvn versions:set -DremoveSnaphot versions:commit
+
+      - name: Build with Maven
+        run: mvn -B clean package --file pom.xml
+
+      - name: Add tag and commit release
+        id: publish-release
+        run: |
+          git add pom.xml
+          release_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "release_version=$release_version" >> $GITHUB_OUTPUT
+          git commit -m "[ ${{ github.event.inputs.release-type}} release $release_version ] "
+          git tag v$release_version -m "${{ github.event.inputs.custom-tag-message }}"
+          git push origin ${{ github.ref_name }}
+          git push origin v$release_version
+          
+      - name: Move app to a new version
+        id: bump-version  
+        run: |
+          if [ -z "${{ github.event.inputs.custom-next-version }}" ]; then
+            if ${{ github.event.inputs.release-type == 'major' }}; then
+              mvn build-helper:parse-version versions:set \
+                  -DnewVersion=\${parsedVersion.nextMajorVersion}.0.0-SNAPSHOT \
+                  versions:commit
+            elif ${{ github.event.inputs.release-type == 'minor' }}; then
+              mvn build-helper:parse-version versions:set \
+                  -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.nextMinorVersion}.0-SNAPHOT \
+                  versions:commit
+            elif ${{ github.event.inputs.release-type == 'patch' }}; then
+              mvn build-helper:parse-version versions:set \
+                  -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVerson.nextPatchVersion}-SNAPSHOT \
+                  versions:commit
+          else
+            mvn versions:set -DnewVersion=${{ github.event.inputs.custom-next-version}}
+          fi
+          next_dev_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "next_dev_version=$next_dev_version" >> $GITHUB_OUTPUT
+          git add pom.xml
+          git commit -m "[Automated release] Change app version to $next_dev_version"
+          git push


### PR DESCRIPTION
# How to use
1. Go to Actions tab, choose CI/CD workflow and click workflow_dispatch
2. If you want to only build docker image choose false under create-release otherwise choose true
3. Choose release type and click `run`
4. If you want a custom release version or a custom next version just fill the proper fields

New releases will only be created when you follow the above procedure, however docker builds are run on push to main branch and also for every tag created. 